### PR TITLE
correct examples in documentation: typo/layout

### DIFF
--- a/doc/toric.xml
+++ b/doc/toric.xml
@@ -599,7 +599,6 @@ gap> Faces(Cones2[1]);
 [ [ 0, 0, 1 ], [ 0, 1, 0 ], [ 1, 0, 0 ] ]
 gap> Faces(Cones2[2]);
 [ [ 1/3, 5/6, 1 ], [ 1/2, 0, -1 ], [ 2, 0, 1 ] ]
-gap>
 </Example>
 <!--
 Cones1:=[[[2,-1],[-1,2]],[[-1,2],[-1,-1]],[[-1,-1],[2,-1]]];;
@@ -647,7 +646,6 @@ yield the desired cones.
 
 <Example>
 gap> Delta0:=[ [ [2,0,0],[0,2,0],[0,0,2] ], [ [2,0,0],[0,2,0],[2,-2,1],[1,2,-2] ] ];;
-gap>
 gap> NumberOfConesOfFan(Delta0,2);
 6
 gap> ConesOfFan(Delta0,2);
@@ -659,7 +657,6 @@ gap> ConesOfFan(Delta0,1);
   [ [ 2, -2, 1 ] ], [ [ 2, 0, 0 ] ] ]
 gap> NumberOfConesOfFan(Delta0,1);
 5
-
 </Example>
 <!--
 Delta0:=[ [ [2,0,0],[0,2,0],[0,0,2] ], [ [2,0,0],[0,2,0],[2,-2,1],[1,2,-2] ] ];;
@@ -689,21 +686,19 @@ i.e., the cones <M>\tau</M> which have <A>sigma</A> as a face.
 
 <Example>
 gap> MaxCones:=[ [ [2,0,0],[0,2,0],[0,0,2] ], 
-                 [ [2,0,0],[0,2,0],[2,-2,1],[1,2,-2] ] ];;
+>                 [ [2,0,0],[0,2,0],[2,-2,1],[1,2,-2] ] ];;
 gap> #this is the set of maximal cones in the fan Delta
 gap> ToricStar([[1,0]],MaxCones);
 [  ]
 gap> ToricStar([[2,0,0],[0,2,0]],MaxCones);
 [ [ [ 0, 2, 0 ], [ 2, 0, 0 ] ], [ [ 2, 0, 0 ], [ 0, 2, 0 ], [ 0, 0, 2 ] ],
   [ [ 2, 0, 0 ], [ 0, 2, 0 ], [ 2, -2, 1 ], [ 1, 2, -2 ] ] ]
-gap>
 gap> MaxCones:=[ [ [2,0,0],[0,2,0],[0,0,2] ], [ [2,0,0],[0,2,0],[1,1,-2] ] ];;
 gap> ToricStar([[2,0,0],[0,2,0]],MaxCones);
 [ [ [ 0, 2, 0 ], [ 2, 0, 0 ] ], [ [ 2, 0, 0 ], [ 0, 2, 0 ], [ 0, 0, 2 ] ],
   [ [ 2, 0, 0 ], [ 0, 2, 0 ], [ 1, 1, -2 ] ] ]
 gap> ToricStar([[1,0]],MaxCones);
 [  ]
-
 </Example>
 <!--
 MaxCones:=[ [ [2,0,0],[0,2,0],[0,0,2] ], [ [2,0,0],[0,2,0],[2,-2,1],[1,2,-2] ] ];;
@@ -754,7 +749,6 @@ gap> L:=[[1,0],[3,4]];; DualSemigroupGenerators([[1,0],[3,4]]);
 gap> L:=[[1,0,0],[1,1,0],[1,1,1],[1,0,1]];;
 gap> DualSemigroupGenerators(L);
 [ [ 0, 0, 0 ], [ 0, 0, 1 ], [ 0, 1, 0 ], [ 1, -1, 0 ], [ 1, 0, -1 ] ]
-gap>
 </Example>
 <!--
 L:=[[1,0],[3,4]];; DualSemigroupGenerators([[1,0],[3,4]]);
@@ -818,7 +812,6 @@ gap> phi:=EmbeddingAffineToricVariety([[1,0],[3,4]]);
 gap> L:=[[1,0,0],[1,1,0],[1,1,1],[1,0,1]];;
 gap> phi:=EmbeddingAffineToricVariety(L);
 [ x_3, x_2, x_1/x_5, x_1/x_6 ]
-
 </Example>
 
 
@@ -856,7 +849,6 @@ desired polytope.
 <Example>
 gap> DivisorPolytope([6,6,0],[[2,-1],[-1,2],[-1,-1]]);
 [ 2*x_1-x_2+6, -x_1+2*x_2+6, -x_1-x_2 ]
-
 </Example>
 
 See also Example 6.13 in <Cite Key="JV02"/>.
@@ -886,8 +878,6 @@ gap> P_Div:=DivisorPolytopeLatticePoints(Div,Delta0,Rays);
   [ -2, -4 ], [ -2, -3 ], [ -2, -2 ], [ -2, -1 ], [ -2, 0 ], [ -2, 1 ],
   [ -2, 2 ], [ -1, -3 ], [ -1, -2 ], [ -1, -1 ], [ -1, 0 ], [ -1, 1 ],
   [ 0, -3 ], [ 0, -2 ], [ 0, -1 ], [ 0, 0 ], [ 1, -2 ], [ 1, -1 ], [ 2, -2 ] ]
-gap>
-
 </Example>
 <!--
 Div:=[6,6,0];; Rays:=[[2,-1],[-1,2],[-1,-1]];;
@@ -917,15 +907,14 @@ This procedure does not check if the fan is complete and nonsingular.
 
 <Example>
 gap> Div:=[6,6,0];; Rays:=[[2,-1],[-1,2],[-1,-1]];;
-gap> Delta:=[[[2,-1],[-1,2]],[[-1,2],[-1,-1]],[[-1,-1],[2,-1]]];;
-gap> RiemannRochBasis(Div,Delta,Rays);
+gap> Delta0:=[[[2,-1],[-1,2]],[[-1,2],[-1,-1]],[[-1,-1],[2,-1]]];;
+gap> RiemannRochBasis(Div,Delta0,Rays);
 [ 1/(x_1^6*x_2^6), 1/(x_1^5*x_2^5), 1/(x_1^5*x_2^4), 1/(x_1^4*x_2^5),
   1/(x_1^4*x_2^4), 1/(x_1^4*x_2^3), 1/(x_1^4*x_2^2), 1/(x_1^3*x_2^4),
   1/(x_1^3*x_2^3), 1/(x_1^3*x_2^2), 1/(x_1^3*x_2), 1/x_1^3, 1/(x_1^2*x_2^4),
   1/(x_1^2*x_2^3), 1/(x_1^2*x_2^2), 1/(x_1^2*x_2), 1/x_1^2, x_2/x_1^2,
   x_2^2/x_1^2, 1/(x_1*x_2^3), 1/(x_1*x_2^2), 1/(x_1*x_2), 1/x_1, x_2/x_1,
   1/x_2^3, 1/x_2^2, 1/x_2, 1, x_1/x_2^2, x_1/x_2, x_1^2/x_2^2 ]
-
 </Example>
 <!--
 Div:=[6,6,0];; Rays:=[[2,-1],[-1,2],[-1,-1]];;
@@ -957,7 +946,6 @@ represented by its list of maximal cones.
 gap> Cones:=[[[2,-1],[-1,2]],[[-1,2],[-1,-1]],[[-1,-1],[2,-1]]];;
 gap> EulerCharacteristic(Cones);
 3
-
 </Example>
 
 Note: <M>X(\Delta)</M> <E>must be non-singular</E>
@@ -1034,7 +1022,6 @@ gap> CardinalityOfToricVariety(Cones,5);
 31
 gap> CardinalityOfToricVariety(Cones,7);
 57
-
 </Example>
 <!--
 Cones:=[[[2,-1],[-1,2]],[[-1,2],[-1,-1]],[[-1,-1],[2,-1]]];;


### PR DESCRIPTION
Correct the layout of some examples to avoid false errors when
testing them (section 5.4 in GAPDoc Reference Manual).