### PR TITLE
Add the GAP Team as package maintainer

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -27,7 +27,15 @@ SetPackageInfo( rec(
                          "USA" ] ),
       Place         := "Annapolis",
       Institution   := "U. S. Naval Academy"
-    )
+    ),
+
+    rec(
+      LastName      := "GAP Team",
+      FirstNames    := "The",
+      IsAuthor      := false,
+      IsMaintainer  := true,
+      Email         := "support@gap-system.org",
+    ),
   ],  
 
   Status  := "accepted",


### PR DESCRIPTION
The last couple releases all were made by @alex-konovalov and me. Perhaps it'd be best to formalize, by adding "The GAP Team" as a package (co-) maintainer, like with many other packages?

@wdjoyner what do you think? And in addition: do you want to keep the "maintainer" flag for yourself set to true? If we add the GAP Team maintainer, this is not strictly necessary (of course as author you'd still be able to make changes at any time you want, including setting that flag bet to true).