### PR TITLE
Fix problems with the Gua05 BibTeX entry.

### DIFF
--- a/doc/toric.bib
+++ b/doc/toric.bib
@@ -15,10 +15,10 @@ year         =       1993
 }
 
 @book{Gua05,
-author       =       "J. Fields, D. Joyner, Cen Tjhai, R. Miller, T. Boothby, R. Baart, 
-J. Cramwinckel, E. Roijackers and E. Minkes,"
-title    =       "Manual for GUAVA - an error-correcting codes 
-package for GAP, version 3.10.",
+author       =       "J. Fields and D. Joyner and Cen Tjhai and R. Miller and T. Boothby and R. Baart and
+J. Cramwinckel and E. Roijackers and E. Minkes",
+title    =       "Manual for GUAVA --- an error-correcting codes
+package for GAP, version 3.10",
 publisher    =       "www.gap-system.org/pkg/guava/",
 year         =       2009
 }


### PR DESCRIPTION
- Fix a misplaced comma that masked all but the author field
- Use the correct separator for multiple authors
- Use an em-dash instead of a hyphen in the title
- Remove a trailing period from the title; BibTex inserts its own punctuation depending on the style